### PR TITLE
fix: Persistent permissions issues with github bot

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout Central Workflows Repo  # Step to checkout the repository containing the central workflows
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Git  # Step to configure Git with necessary details
         run: |


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

- Sync-workflow - added persist-credentials: false to the checkout.


## Why are we doing this?

- To remove the persistent permissions from checkout that comes from the authentication header causing the GIthub Actions bot to error on Permissions.

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done