### PR TITLE
fix: Remove deprecated codeql action v2 in workflows

### DIFF
--- a/.github/workflows/dockerfile-linter.yml
+++ b/.github/workflows/dockerfile-linter.yml
@@ -43,7 +43,7 @@ jobs:
           no-fail: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: hadolint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -51,7 +51,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       
       
-      * name: Generate artifact attestation
+      - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}

--- a/.github/workflows/terraform-security.yml
+++ b/.github/workflows/terraform-security.yml
@@ -34,7 +34,7 @@ jobs:
           sarif_file: tfsec.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: tfsec.sarif


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change? Removed deprecated codeql action v2 in workflows; also fixed syntax error in unrelated file

## Why are we doing this? Fix for issue 418

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done