### PR TITLE
ci: remove Node.js 16 from CI matrix (EOL Sep 2023)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,7 @@ jobs:
     name: run build
     strategy:
       matrix:
-        node-version: [16, 20]
+        node-version: [20]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Removes Node.js 16 from the CI build matrix in `node.js.yml`. Node 16 reached end-of-life in September 2023; the matrix is changed from `[16, 20]` to `[20]`.