### PR TITLE
fix: scorecard dev-push failure and gpg-verify logic bugs

### DIFF
--- a/.github/workflows/gpg-verify.yml
+++ b/.github/workflows/gpg-verify.yml
@@ -10,7 +10,10 @@ on: [pull_request]  # Trigger this workflow on pull request events
 
 jobs:
   gpg-verify:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'dependabot-preview[bot]' &&
+      github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest  # Use the latest Ubuntu runner for the job
     steps:
     - uses: actions/checkout@v4  # Checkout the repository code using the actions/checkout action
@@ -26,18 +29,23 @@ jobs:
 
     - name: Check GPG verification status  # Step to check each commit for GPG signature verification
       run: |
-        # Get the list of commits in the pull request
-        commits=$(git log --pretty=format:%H origin/${PR_HEAD_REF}..origin/${PR_BASE_REF})
-        
-        # Check the GPG verification status of each commit
+        # Get the list of commits in the pull request (head commits not yet in base)
+        commits=$(git log --pretty=format:%H origin/${PR_BASE_REF}..origin/${PR_HEAD_REF})
+
+        if [[ -z "$commits" ]]; then
+          echo "No commits to verify."
+          exit 0
+        fi
+
+        # Check the GPG verification status of each commit via the GitHub commit API
         for commit in $commits; do
-          status=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit/check-runs \
-            | jq -r '.check_runs[] | select(.name == "GPG verify") | .conclusion')
-          
-          # If the GPG verification status is not successful, list the commit and exit with a non-zero status
-          if [[ "$status" != "success" ]]; then
-            echo "GPG signature verification failed for commit $commit."
-            exit 1
+          verified=$(curl -s \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit \
+            | jq -r '.commit.verification.verified')
+
+          # If the commit is not verified, list it and exit with a non-zero status
+          if [[ "$verified" != "true" ]]; then
           fi
         done

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - main
-      - dev
 
 # Scorecard workflow restrictions (enforced when publish_results=true):
 #   - No workflow-level env vars or defaults
@@ -40,9 +39,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          # Publish results (badge + REST API) only when running on the default
-          # branch or on a schedule/branch-protection event.  Dev-branch runs
-          # still score the repo but do not overwrite the published badge.
+# Publish results (badge + REST API) on main, schedule, and branch_protection_rule events.
           publish_results: ${{ github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'branch_protection_rule' }}
 
       - name: "Upload artifact"


### PR DESCRIPTION
Port of [tazama-lf/workflows#46](https://github.com/tazama-lf/workflows/pull/46). Identical fixes applied to both repos.

## scorecard.yml

`ossf/scorecard-action@v2.4.3` enforces a hard constraint that it can only run on the repository's default branch. Triggering on `dev` fails immediately with `Only the default branch main is supported`.

**Fix:** Remove `dev` from `push.branches`. Triggers are now `push: [main]`, schedule (weekly), `branch_protection_rule`.

## gpg-verify.yml

Three bugs fixed:

**1. Actor exclusion incomplete** — `github-actions[bot]` was not excluded. Automated sync PRs always failed GPG check because the bot cannot sign commits.

**2. Inverted git log range**
```bash
# Before (wrong)
git log origin/${PR_HEAD_REF}..origin/${PR_BASE_REF}
# After (correct)
git log origin/${PR_BASE_REF}..origin/${PR_HEAD_REF}
```

**3. Wrong API endpoint** — was querying `/commits/:sha/check-runs` for a check named `"GPG verify"` (circular self-reference, returns empty on first run). Now uses `/commits/:sha` → `.commit.verification.verified`, which is the correct server-side GPG verification result.

**Bonus:** Empty commit range guard added (exits 0 cleanly instead of looping over nothing).