### PR TITLE
fix: delete package-lock.json before npm install to prevent stale rule dep resolution

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -149,6 +149,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
+          rm -f package-lock.json
           npm install
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}


### PR DESCRIPTION
When \package.json\ is rewritten by \sed\ to replace the rule dependency alias, the existing \package-lock.json\ still has the old \esolved\ URL in its \packages\ section. npm honours the lock over \package.json\ and installs the wrong tarball (e.g. \ule-901\ instead of \ule-011\). Deleting the lock before \
pm install\ forces a clean resolution from the registry.