### PR TITLE
fix: delete package-lock.json before npm install in stable build workflow

### DIFF
--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -149,6 +149,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
+          rm -f package-lock.json
           npm install
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}


### PR DESCRIPTION
Same fix as #79 but for `package-rule.yml` (stable/main builds).

The old per-repo workflow explicitly deleted `package-lock.json` before `npm install` — this was lost during centralisation. Without it, npm's `packages` section in the lock overrides the `sed`-rewritten `package.json` and installs the wrong rule tarball.