### PR TITLE
feat(ci): replace legacy node.js.yml with reusable node-ci.yml and synced caller stub

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable Node.js CI workflow: build, lint, and test.
+# Called by consumer repos via a thin stub (node.js.yml) that uses this workflow.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Node.js CI (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  NPM_SCOPE: "@frmscoe"
+  NPM_REGISTRY: "https://npm.pkg.github.com/"
+  NODE_ENV: 'test'
+
+jobs:
+  build:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    name: run build
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Use Node.js 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: ${{ env.NPM_REGISTRY }}
+          scope: ${{ env.NPM_SCOPE }}
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run build
+        run: npm run build
+
+  lint:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    name: check style
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Use Node.js 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: ${{ env.NPM_REGISTRY }}
+          scope: ${{ env.NPM_SCOPE }}
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check linting
+        run: npm run lint
+
+  test:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    name: check tests
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Use Node.js 20
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: ${{ env.NPM_REGISTRY }}
+          scope: ${{ env.NPM_SCOPE }}
+      - name: Install dependencies
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,86 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+# Caller stub: delegates all Node.js CI logic to the centralised reusable workflow.
+# Logic changes belong in node-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
 name: Node.js CI
-
-env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  NPM_SCOPE: "@frmscoe"
-  NPM_REGISTRY: "https://npm.pkg.github.com/"
-  NODE_ENV: 'test'
-  STARTUP_TYPE: 'nats'
 
 on:
   push:
     branches: [ "dev", "main" ]
   pull_request:
     branches: [ "dev", "main" ]
+
+permissions:
+  contents: read
+
 jobs:
-  build:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    name: run build
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          registry-url: ${{ env.NPM_REGISTRY }}
-          scope: ${{ env.NPM_SCOPE }}
-      - name: Install dependencies 
-        run: npm ci
-      - name: Run build
-        run: npm run build
-
-  lint:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    name: check style
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          registry-url: ${{ env.NPM_REGISTRY }}
-          scope: ${{ env.NPM_SCOPE }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Check linting
-        run: npm run lint
-
-  test:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    name: check tests
-    strategy:
-      matrix:
-        node-version: [20]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-          registry-url: ${{ env.NPM_REGISTRY }}
-          scope: ${{ env.NPM_SCOPE }}
-      - name: Install dependencies
-        run: npm ci
-      - name: Run tests
-        run: npm test
+  node-ci:
+    uses: frmscoe/workflows/.github/workflows/node-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -119,7 +119,7 @@ jobs:
           mkdir -p temp-workflows
           cp -r .github/workflows/* temp-workflows/
           rm temp-workflows/sync-workflows.yml  # avoid recursive syncing
-          rm -f temp-workflows/node.js.yml       # preserve per-repo benchmark customisations
+          rm -f temp-workflows/node-ci.yml       # reusable workflow stays in this repo; consumer repos reference it at runtime via @dev
 
           for repo in $REPOS; do
             git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/frmscoe/$repo.git

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ tazama-lf/workflows  →  (manual PR)  →  frmscoe/workflows  →  (auto sync o
 | Sync targets | 33 frmscoe rule repos | 26 tazama-lf repos |
 | Sync segmentation | None — all repos receive the same file set | `SPECIFIC_REPOS` / `PUBLISH_REPOS` / `RULE_REPOS` groups |
 | Missing workflows | `dockerfile-linter.yml`, `dockerhub-image-build.yml`, `dockerhub-image-build-rc.yml` | All canonical files present |
+| Node.js CI | `node-ci.yml` uses `NPM_SCOPE: @frmscoe`; stub calls `frmscoe/workflows/node-ci.yml@dev` | `node-ci.yml` uses `NPM_SCOPE: @tazama-lf`; stub calls `tazama-lf/workflows/node-ci.yml@dev` |
 
 ---
 
@@ -50,11 +51,11 @@ tazama-lf/workflows  →  (manual PR)  →  frmscoe/workflows  →  (auto sync o
 
 All 33 rule repos receive:
 
-`branch-target-check.yml`, `codacy.yml`, `codeql.yml`, `conventional-commits.yml`, `dco-check.yml`, `dependency-review.yml`, `gpg-verify.yml`, `milestone.yml`, `njsscan.yml`, `publish.yml`, `release-train.yml`, `release.yml`, `sbom.yml`, `scorecard.yml`, `version-check.yml`
+`branch-target-check.yml`, `codacy.yml`, `codeql.yml`, `conventional-commits.yml`, `dco-check.yml`, `dependency-review.yml`, `gpg-verify.yml`, `milestone.yml`, `njsscan.yml`, `node.js.yml` (caller stub), `publish.yml`, `release-train.yml`, `release.yml`, `sbom.yml`, `scorecard.yml`, `version-check.yml`
 
 Plus per-repo caller stubs for: `package-rule-rc.yml` (fires on `push: dev`) and `package-rule.yml` (fires on `push: main`)
 
-**Not distributed:** `sync-workflows.yml`, `node.js.yml` (each repo maintains its own copy), `package-rule*.yml` canonical reusable definitions (replaced with caller stubs)
+**Not distributed:** `sync-workflows.yml`, `node-ci.yml` (reusable workflow stays in this repo; consumer repos reference it at runtime via `@dev` ref), `package-rule*.yml` canonical reusable definitions (replaced with caller stubs)
 
 ---
 
@@ -81,7 +82,8 @@ Individual workflow documentation is in [`workflow-docs/`](workflow-docs/). For 
 | [`gpg-verify.md`](workflow-docs/gpg-verify.md) | → tazama-lf docs |
 | [`milestone.md`](workflow-docs/milestone.md) | → tazama-lf docs |
 | [`njsscan.md`](workflow-docs/njsscan.md) | → tazama-lf docs |
-| [`nodejs.md`](workflow-docs/nodejs.md) | → tazama-lf docs (⚠️ `NPM_SCOPE=@frmscoe`) |
+| [`node-ci.md`](workflow-docs/node-ci.md) | frmscoe-specific (`NPM_SCOPE=@frmscoe`) |
+| [`nodejs.md`](workflow-docs/nodejs.md) | → tazama-lf docs |
 | [`package-rule-rc.md`](workflow-docs/package-rule-rc.md) | frmscoe-specific |
 | [`package-rule.md`](workflow-docs/package-rule.md) | frmscoe-specific |
 | [`publish.md`](workflow-docs/publish.md) | frmscoe-specific (`@frmscoe` scope) |

--- a/workflow-docs/node-ci.md
+++ b/workflow-docs/node-ci.md
@@ -1,0 +1,81 @@
+# `node-ci.yml`
+
+> **frmscoe variant** of the reusable Node.js CI workflow. The upstream canonical version lives in [`tazama-lf/workflows`](https://github.com/tazama-lf/workflows/blob/dev/workflow-docs/node-ci.md). The only difference is the `NPM_SCOPE` value (`@frmscoe` vs `@tazama-lf`).
+
+## Purpose
+
+Reusable Node.js CI pipeline with three parallel jobs - build, lint, and test - running against Node.js 20. Contains all CI logic for Node.js consumer repos. Called by the [`node.js.yml`](nodejs.md) caller stub which is synced to all 33 rule repos.
+
+This file is **not synced** to consumer repos - it stays in `frmscoe/workflows` and is referenced by the stub at runtime via `uses: frmscoe/workflows/.github/workflows/node-ci.yml@dev`.
+
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `workflow_call` | Called by `node.js.yml` stub in consumer repos |
+
+---
+
+## Execution Context
+
+| Property | Value |
+|----------|-------|
+| Runner | `ubuntu-latest` |
+| Node version | `20` |
+| Permissions | `contents: read` |
+
+---
+
+## Environment Variables
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `NPM_SCOPE` | `@frmscoe` | npm scope for GitHub Packages registry routing |
+| `NPM_REGISTRY` | `https://npm.pkg.github.com/` | GitHub Packages registry URL |
+| `NODE_ENV` | `test` | sets test environment for all jobs |
+
+---
+
+## Jobs
+
+### `build` - run build
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
+2. `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0) - Node 20, npm cache, registry and scope
+3. `npm ci` (authenticated via `NODE_AUTH_TOKEN: secrets.GITHUB_TOKEN`)
+4. `npm run build`
+
+### `lint` - check style
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
+2. `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0)
+3. `npm ci` (authenticated via `NODE_AUTH_TOKEN: secrets.GITHUB_TOKEN`)
+4. `npm run lint`
+
+### `test` - check tests
+
+1. `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
+2. `actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f` (v6.3.0)
+3. `npm ci` (authenticated via `NODE_AUTH_TOKEN: secrets.GITHUB_TOKEN`)
+4. `npm test`
+
+---
+
+## Sync Distribution
+
+| Group | Behaviour |
+|-------|----------|
+| **All repos** | **Not synced** - reusable workflow stays in `frmscoe/workflows` only; consumer repos reference it by the `@dev` branch ref at runtime |
+
+The caller stub (`node.js.yml`) is what gets synced. See [`nodejs.md`](nodejs.md).
+
+---
+
+## Dependencies (pinned actions)
+
+| Action | Pinned SHA | Semver alias |
+|--------|-----------|--------------|
+| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
+| `actions/setup-node` | `53b83947a5a98c8d113130e565377fae1a50d02f` | v6.3.0 |

--- a/workflow-docs/nodejs.md
+++ b/workflow-docs/nodejs.md
@@ -1,12 +1,43 @@
 # `node.js.yml`
 
-> This workflow is distributed from [`tazama-lf/workflows`](https://github.com/tazama-lf/workflows) as the base reference. For full documentation — including trigger details, job steps, and limitations — see:
->
-> **[`workflow-docs/nodejs.md` in tazama-lf/workflows](https://github.com/tazama-lf/workflows/blob/dev/workflow-docs/nodejs.md)**
->
-> **Note: `node.js.yml` is NOT synced to target repos by `sync-workflows.yml`.** Each repo maintains its own copy.
+Caller stub that delegates Node.js CI to the centralised reusable workflow [`node-ci.yml`](node-ci.md). Contains only the push/PR triggers and a single `uses:` reference - no logic lives here. This file is synced to all 33 rule repos unchanged.
 
-## frmscoe-specific notes
+> **Upstream reference:** [`workflow-docs/nodejs.md` in tazama-lf/workflows](https://github.com/tazama-lf/workflows/blob/dev/workflow-docs/nodejs.md) - the architecture is identical; only the reusable workflow org differs (`frmscoe` vs `tazama-lf`).
 
-- `NPM_SCOPE` is set to `@frmscoe` (instead of `@tazama-lf` as in the canonical file).
-- All other behaviour is identical.
+---
+
+## Trigger
+
+| Event | Conditions |
+|-------|-----------|
+| `push` | branches: `[dev, main]` |
+| `pull_request` | branches: `[dev, main]` |
+
+---
+
+## Jobs
+
+### `node-ci`
+
+Delegates entirely to the reusable workflow:
+
+```yaml
+uses: frmscoe/workflows/.github/workflows/node-ci.yml@dev
+secrets: inherit
+```
+
+See [`node-ci.yml` documentation](node-ci.md) for the full job breakdown.
+
+---
+
+## Permissions
+
+| Scope | Level |
+|-------|-------|
+| `contents` | `read` |
+
+---
+
+## Sync Distribution
+
+Synced to all 33 frmscoe rule repos unchanged.


### PR DESCRIPTION
Mirror of [tazama-lf/workflows #95](https://github.com/tazama-lf/workflows/pull/95).

## Summary

Replaces the full 80-line `node.js.yml` with the reusable workflow + thin caller stub pattern piloted in `tazama-lf/workflows`.

## Changes

- **New:** `.github/workflows/node-ci.yml` - reusable workflow (`workflow_call`); holds all build/lint/test logic. `NPM_SCOPE: @frmscoe`. Not synced to rule repos.
- **Modified:** `.github/workflows/node.js.yml` - replaced with 22-line caller stub delegating to `frmscoe/workflows/.github/workflows/node-ci.yml@dev` via `secrets: inherit`. Synced to all 33 rule repos.
- **Modified:** `.github/workflows/sync-workflows.yml` - exclusion updated: `node-ci.yml` excluded (was `node.js.yml`), so the stub is now distributed and the reusable stays here.
- **New:** `workflow-docs/node-ci.md` - documentation for the reusable workflow.
- **Modified:** `workflow-docs/nodejs.md` - rewritten to describe the stub pattern.
- **Modified:** `README.md` - differences table, distributed workflows list, and docs table updated.

## Difference from tazama-lf/workflows

The only code difference: `NPM_SCOPE: "@frmscoe"` (vs `@tazama-lf`) and the stub points to `frmscoe/workflows/node-ci.yml@dev` (vs `tazama-lf/workflows/...`).

Signed-off-by: Justus-at-Tazama <123470803+Justus-at-Tazama@users.noreply.github.com>