### PR TITLE
fix(ci): add issues:write permission and upgrade Node 20 to 22 LTS

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   validate-pr-title:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 env:
   NPM_SCOPE: "@frmscoe"
@@ -26,10 +27,10 @@ jobs:
     name: run build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: ${{ env.NPM_SCOPE }}
@@ -47,10 +48,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: ${{ env.NPM_SCOPE }}
@@ -68,10 +69,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: ${{ env.NPM_REGISTRY }}
           scope: ${{ env.NPM_SCOPE }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   node-ci:

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Read rule version from package.json
         id: rule_version

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Read rule version from package.json
         id: rule_version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com/'
           scope: '@frmscoe'
 

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com/'
           scope: '@frmscoe'
 


### PR DESCRIPTION
Mirrors changes from tazama-lf/workflows#102.\n\n## Changes\n\n- `conventional-commits.yml` - add `issues: write` permission (required for label management)\n- `node-ci.yml` - add `packages: read` permission; upgrade Node 20 to 22 LTS in all three jobs (build, lint, test)\n- `node.js.yml` - add `packages: read` permission\n- `package-rule-rc.yml` - upgrade Node 20 to 22 LTS\n- `package-rule.yml` - upgrade Node 20 to 22 LTS\n- `publish.yml` - upgrade Node 20 to 22 LTS\n- `release-train.yml` - upgrade Node 20 to 22 LTS\n\nNote: `library-dependency-rollout.yml` change from the upstream PR does not apply here as that file is not present in this repo.