### PR TITLE
ci: replace SSH_SIGNING_KEY with GitHub App token in sync-workflows

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -25,51 +25,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Git  # Step to configure Git with necessary details
-        run: |
-          git config --global user.name 'Justus-at-Tazama'
-          git config --global user.email '123470803+Justus-at-Tazama@users.noreply.github.com'
-          git config --global credential.helper store
-          # Configure SSH commit signing so sync commits show as Verified on GitHub.
-          # SSH_SIGNING_KEY must be stored base64-encoded (single line, no wrapping) to avoid
-          # line-ending corruption. Set with: base64 -w 0 signing_key | gh secret set SSH_SIGNING_KEY
-          # The corresponding public key must be registered as a Signing Key on the GitHub account
-          # that GH_TOKEN belongs to: Settings -> SSH and GPG keys -> New signing key.
-          if [ -z "${{ secrets.SSH_SIGNING_KEY }}" ]; then
-            echo "::error::SSH_SIGNING_KEY secret is not set. Commits cannot be signed. Add the secret before running the sync." >&2
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          # Decode the base64 secret directly to the key file -- no line-ending issues possible.
-          echo "${{ secrets.SSH_SIGNING_KEY }}" | base64 -d > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
-          # Validate the key is a usable Ed25519/RSA private key before enabling signing.
-          ssh-keygen -y -f ~/.ssh/signing_key > /dev/null || {
-            echo "::error::SSH_SIGNING_KEY is not a valid SSH private key or is passphrase-protected. Fix the secret before running the sync." >&2
-            exit 1
-          }
-          git config --global gpg.format ssh
-          git config --global user.signingkey ~/.ssh/signing_key
-          git config --global commit.gpgsign true
+      - name: Generate GitHub App token
+        id: app_token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e  # v2.0.6
+        with:
+          app-id: ${{ secrets.TAZAMA_BOT_APP_ID }}
+          private-key: ${{ secrets.TAZAMA_BOT_PRIVATE_KEY }}
+          owner: frmscoe
 
-      - name: Get actor details  # Step to get the triggering actor details for the Signed-off-by line
-        id: pr_author
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Git identity
         run: |
-          # For pull_request events use the PR author login; for push/workflow_dispatch fall back to the triggering actor.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_AUTHOR_NAME=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}" --jq '.user.login')
-            PR_AUTHOR_NAME_FULL=$(git log -1 --pretty=format:'%an')
-            PR_AUTHOR_EMAIL=$(git log -1 --pretty=format:'%ae')
-          else
-            PR_AUTHOR_NAME="${{ github.actor }}"
-            PR_AUTHOR_NAME_FULL="${{ github.actor }}"
-            PR_AUTHOR_EMAIL="${{ github.actor }}@users.noreply.github.com"
-          fi
-          echo "PR_AUTHOR_NAME=${PR_AUTHOR_NAME}" >> $GITHUB_ENV
-          echo "PR_AUTHOR_EMAIL=${PR_AUTHOR_EMAIL}" >> $GITHUB_ENV
-          echo "PR_AUTHOR_NAME_FULL=${PR_AUTHOR_NAME_FULL}" >> $GITHUB_ENV
+          git config --global user.name 'tazama-lf-ci-bot[bot]'
+          git config --global user.email '282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com'
 
       - name: Sync Workflows to Other Repos  # Step to sync workflows to other repositories
         env:
@@ -108,9 +75,9 @@ jobs:
             rule-090
             rule-091
           PR_REVIEWERS: ${{ secrets.GH_USERNAME }}  # List of reviewers
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
-          SIGNED_OFF_BY="Signed-off-by: ${{ env.PR_AUTHOR_NAME_FULL }} <${{ env.PR_AUTHOR_EMAIL }}>"
+          SIGNED_OFF_BY="Signed-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>"
 
           # Capture the workspace root so we can reference config-templates/ after cd-ing into each repo
           WORKFLOWS_ROOT="${GITHUB_WORKSPACE}"
@@ -125,9 +92,9 @@ jobs:
           rm -f temp-workflows/node-ci.yml       # reusable workflow stays in this repo; consumer repos reference it at runtime via @dev
 
           for repo in $REPOS; do
-            git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/frmscoe/$repo.git
+            git clone https://x-access-token:${GH_TOKEN}@github.com/frmscoe/$repo.git
             cd $repo
-            git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/frmscoe/$repo.git
+            git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/frmscoe/$repo.git
 
             # Ensure dev branch exists in target repo -- create from default branch if absent.
             if ! git ls-remote --heads origin dev | grep -q dev; then


### PR DESCRIPTION
Replaces the SSH_SIGNING_KEY-based commit signing and hardcoded user identity with the `tazama-lf-ci-bot` GitHub App token.\n\n## Changes\n\n- Remove "Set up Git" step that required `SSH_SIGNING_KEY` and `GH_TOKEN` org secrets (user-bound, never reliably set)\n- Remove "Get actor details" step (no longer needed)\n- Add `actions/create-github-app-token` step to generate a short-lived installation token for the `frmscoe` org\n- Set git identity to `tazama-lf-ci-bot[bot]` for all commits made by this workflow\n- Use the app token for all clone, push, and `gh` CLI calls\n\n## Prerequisites\n\nThe following org-level secrets must be set on the `frmscoe` org (visibility: all repositories):\n- `TAZAMA_BOT_APP_ID` - the numeric App ID for `tazama-lf-ci-bot`\n- `TAZAMA_BOT_PRIVATE_KEY` - the PEM private key for the app\n\nBoth secrets were set as part of the parallel change in `tazama-lf/workflows` (PR #105).\n\nSigned-off-by: tazama-lf-ci-bot[bot] <282868230+tazama-lf-ci-bot[bot]@users.noreply.github.com>