### PR TITLE
fix(ci): split lint step so prettier does not fail check-style job

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -59,8 +59,11 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check linting
-        run: npm run lint
+      - name: Check linting (ESLint)
+        run: npm run lint:eslint
+      - name: Check linting (Prettier)
+        run: npm run lint:prettier
+        continue-on-error: true
 
   test:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'


### PR DESCRIPTION
Synced from tazama-lf/workflows PR #113.

Splits the single "Check linting" step into two steps:

- **Check linting (ESLint)** - runs `npm run lint:eslint`. Fails the job on genuine code errors.
- **Check linting (Prettier)** - runs `npm run lint:prettier` with `continue-on-error: true`. Reports formatting issues without blocking the job.