### PR TITLE
fix(ci): expose GH_TOKEN on npm ci steps in node-ci.yml

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -38,6 +38,7 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run build
         run: npm run build
 
@@ -59,6 +60,7 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check linting (ESLint)
         run: npm run lint:eslint
       - name: Check linting (Prettier)
@@ -83,5 +85,6 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: npm test


### PR DESCRIPTION
## Summary

Synced from [tazama-lf/workflows#114](https://github.com/tazama-lf/workflows/pull/114).

## Problem

Repos whose `.npmrc` uses `${GH_TOKEN}` for GitHub Packages authentication were getting 401 Unauthorized errors during `npm ci` in CI when the npm cache was cold.

Root cause: `actions/setup-node` writes `NODE_AUTH_TOKEN` into `~/.npmrc`, but the project-level `.npmrc` (which uses `${GH_TOKEN}`) takes precedence. Since `GH_TOKEN` was never set in the workflow env, npm resolved it to empty and requests were unauthenticated.

## Fix

Add `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` alongside `NODE_AUTH_TOKEN` on all three `npm ci` steps (build, lint, test jobs). Both variables are now set, so repos using either convention authenticate correctly.
