### PR TITLE
ci: refactor codacy scan to reusable workflow with docker tools disabled

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,17 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow checks out code, performs a Codacy security scan
-# and integrates the results with the
-# GitHub Advanced Security code scanning feature.  For more information on
-# the Codacy security scan action usage and parameters, see
-# https://github.com/codacy/codacy-analysis-cli-action.
-# For more information on Codacy Analysis CLI in general, see
-# https://github.com/codacy/codacy-analysis-cli.
+# Caller stub: delegates all Codacy scan logic to the centralised reusable workflow.
+# Logic changes belong in codacy-ci.yml in tazama-lf/workflows - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -21,65 +11,16 @@ on:
   push:
     branches: [ "dev", "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "dev", "main" ]
   schedule:
     - cron: '17 0 * * 4'
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 jobs:
   codacy-security-scan:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    name: Codacy Security Scan
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
-        with:
-          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
-          # You can also omit the token and run the tools that support default configurations
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          verbose: true
-          output: results.sarif
-          format: sarif
-          # Adjust severity of non-security issues
-          gh-code-scanning-compat: true
-          # Force 0 exit code to allow SARIF file generation
-          # This will handover control about PR rejection to the GitHub side
-          max-allowed-issues: 2147483647
-
-      # Codacy outputs one SARIF run per engine. The CodeQL upload-sarif action rejects
-      # files with multiple runs sharing the same category (enforced since 2025-07-21).
-      # Merge all runs into one before uploading.
-      - name: Merge SARIF runs into single run
-        run: |
-          jq '
-            if (.runs | length) > 1 then
-              .runs = [{
-                "tool": {
-                  "driver": {
-                    "name": "Codacy",
-                    "informationUri": "https://www.codacy.com",
-                    "rules": ([.runs[].tool.driver.rules[]?] | unique_by(.id))
-                  }
-                },
-                "results": [.runs[].results[]?]
-              }]
-            else . end
-          ' results.sarif > merged.sarif && mv merged.sarif results.sarif
-
-      # Upload the SARIF file generated in the previous step
-      - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@60168ffe96596fce55ee3851b6bb7b2e1ea8dbb0  # v4.35.1
-        with:
-          sarif_file: results.sarif
-          category: codacy
+    uses: tazama-lf/workflows/.github/workflows/codacy-ci.yml@dev
+    secrets: inherit


### PR DESCRIPTION
Mirrors tazama-lf/workflows#116.

Replaces the inline Codacy scan logic in `codacy.yml` with a thin caller stub that delegates to the centralised reusable workflow in `tazama-lf/workflows`.

- All scan logic (docker tools disabled, SARIF merge, upload) now lives in `codacy-ci.yml` in `tazama-lf/workflows`
- This repo carries only the stub - no logic changes needed here going forward
