### PR TITLE
ci: replace npm install with --package-lock-only --ignore-scripts in package-rule-rc

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -146,11 +146,28 @@ jobs:
             exit 1
           fi
 
-      - name: Install dependencies
+      - name: Regenerate package-lock.json for rule ${{ inputs.rule_number }}
         run: |
           cd "rule-executer-${{ inputs.rule_number }}"
+          # Delete the stale lock file so npm generates a fresh one from the
+          # modified package.json (which now references the correct rule module).
+          # Without this, `npm ci` in the Docker build follows the old lock file
+          # and installs the wrong rule module regardless of package.json.
           rm -f package-lock.json
-          npm install
+          npm install --package-lock-only --ignore-scripts
+          # Verify the lock file was regenerated with the correct rule module
+          RULE_NUM="${{ inputs.rule_number }}"
+          RULE_ORG="${{ inputs.rule_org }}"
+          case "$RULE_ORG" in
+            frmscoe)   EXPECTED_SCOPE="@frmscoe" ;;
+            tazama-lf) EXPECTED_SCOPE="@tazama-lf" ;;
+          esac
+          if ! grep -q "\"name\": \"${EXPECTED_SCOPE}/rule-${RULE_NUM}\"" package-lock.json; then
+            echo "❌ package-lock.json was not updated to reference ${EXPECTED_SCOPE}/rule-${RULE_NUM}"
+            grep '"name": "@' package-lock.json | grep rule | head -5 || true
+            exit 1
+          fi
+          echo "✅ package-lock.json correctly references ${EXPECTED_SCOPE}/rule-${RULE_NUM}"
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 


### PR DESCRIPTION
## Context

Aligns `frmscoe/workflows` with the fix applied to `tazama-lf/workflows` (PRs #118, #119).

The root cause of the rule-902 production incident: `npm ci` in the Docker build is strictly deterministic - it follows the lock file, not `package.json`. The sed substitution updates `package.json` with the correct rule module (e.g. rule-901 -> rule-002), but the cloned `package-lock.json` still referenced the old module. So `npm ci` installed the wrong rule regardless.

`frmscoe/workflows` already had `rm -f package-lock.json` before `npm install`, which partially addressed this. This PR completes the fix by:

- Switching to `--package-lock-only` - only the lock file is written, no `node_modules` installed locally (Docker handles the actual install via `npm ci`)
- Adding `--ignore-scripts` - skips lifecycle hooks including `husky prepare`, which fails with exit 127 when `node_modules` is absent
- Adding a post-generate validation grep that confirms the lock file references the correct rule module before the Docker build starts

## Changes

- Renamed step from "Install dependencies" to "Regenerate package-lock.json for rule NNN" (matches canonical)
- `npm install` -> `npm install --package-lock-only --ignore-scripts`
- Added validation grep with explicit `exit 1` on mismatch
