### PR TITLE
fix(ci): replace broken codeql-action upload-sarif SHA with valid v3 pin

### DIFF
--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         args: '. --sarif --output results.sarif'
     - name: Upload njsscan report
-      uses: github/codeql-action/upload-sarif@60168ffe96596fce55ee3851b6bb7b2e1ea8dbb0  # v4.35.1
+      uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
       if: steps.njsscan.outcome == 'success'
       with:
         sarif_file: results.sarif


### PR DESCRIPTION
## Problem

`njsscan.yml` line 46 referenced a `github/codeql-action/upload-sarif` SHA that does not exist on any valid tag:

```
github/codeql-action/upload-sarif@60168ffe96596fce55ee3851b6bb7b2e1ea8dbb0  # v4.35.1
```

This SHA is invalid - `codeql-action` has no v4.35.1 release, causing the njsscan workflow to fail on every run.

## Fix

Replace the broken SHA with the valid v3 pin used in the canonical `tazama-lf/workflows` source:

```
github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
```

This matches the SHA pinned in `tazama-lf/workflows/njsscan.yml`.
