### PR TITLE
ci: pilot gpg-verify stub migration + sync *-ci.yml exclusion fix

### DIFF
--- a/.github/workflows/gpg-verify-ci.yml
+++ b/.github/workflows/gpg-verify-ci.yml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable GPG/SSH/S-MIME signature verification workflow.
+# Called by consumer repos via a thin stub (gpg-verify.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Signature Verify (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  gpg-verify:
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'dependabot-preview[bot]' &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        fetch-depth: 0
+
+    - name: Set up environment variables
+      env:
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+      run: |
+        printf 'PR_HEAD_SHA=%s\n' "$PR_HEAD_SHA" >> "$GITHUB_ENV"
+        printf 'PR_BASE_SHA=%s\n' "$PR_BASE_SHA" >> "$GITHUB_ENV"
+        printf 'GITHUB_TOKEN=%s\n' "$GH_TOKEN" >> "$GITHUB_ENV"
+        printf 'GITHUB_REPOSITORY=%s\n' "$GH_REPO" >> "$GITHUB_ENV"
+
+    - name: Check GPG verification status
+      run: |
+        commits=$(git log --pretty=format:%H "$PR_BASE_SHA..$PR_HEAD_SHA")
+
+        if [[ -z "$commits" ]]; then
+          echo "No commits to verify."
+          exit 0
+        fi
+
+        for commit in $commits; do
+          response=$(curl -sS --max-time 10 --fail \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit") || {
+            curl_exit=$?
+            echo "GitHub API request failed for commit $commit (curl exit $curl_exit). Check network or API availability."
+            exit "$curl_exit"
+          }
+
+          verified=$(echo "$response" | jq -r '.commit.verification.verified')
+
+          if [[ "$verified" != "true" ]]; then
+            echo "GPG signature verification failed for commit $commit."
+            exit 1
+          fi
+        done

--- a/.github/workflows/gpg-verify.yml
+++ b/.github/workflows/gpg-verify.yml
@@ -1,63 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This GitHub Actions workflow checks that all commits in a pull request (PR) have a verified cryptographic signature (GPG, SSH, or S/MIME).
+# Caller stub: delegates all signature verification logic to the centralised reusable workflow.
+# Logic changes belong in gpg-verify-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
 name: Signature Verify
 
-on: [pull_request]  # Trigger this workflow on pull request events
+on: [pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   gpg-verify:
-    if: |
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'dependabot-preview[bot]' &&
-      github.actor != 'github-actions[bot]'
-    runs-on: ubuntu-latest  # Use the latest Ubuntu runner for the job
-    steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        fetch-depth: 0  # Fetch all history for all branches to ensure we have the full commit history
-
-    - name: Set up environment variables
-      env:
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_REPO: ${{ github.repository }}
-      run: |
-        printf 'PR_HEAD_SHA=%s\n' "$PR_HEAD_SHA" >> "$GITHUB_ENV"
-        printf 'PR_BASE_SHA=%s\n' "$PR_BASE_SHA" >> "$GITHUB_ENV"
-        printf 'GITHUB_TOKEN=%s\n' "$GH_TOKEN" >> "$GITHUB_ENV"
-        printf 'GITHUB_REPOSITORY=%s\n' "$GH_REPO" >> "$GITHUB_ENV"
-
-    - name: Check GPG verification status  # Step to check each commit for GPG signature verification
-      run: |
-        # Get the list of commits in the pull request (head commits not yet in base)
-        commits=$(git log --pretty=format:%H "$PR_BASE_SHA..$PR_HEAD_SHA")
-
-        if [[ -z "$commits" ]]; then
-          echo "No commits to verify."
-          exit 0
-        fi
-
-        # Check the GPG verification status of each commit via the GitHub commit API
-        for commit in $commits; do
-          response=$(curl -sS --max-time 10 --fail \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit") || {
-            curl_exit=$?
-            echo "GitHub API request failed for commit $commit (curl exit $curl_exit). Check network or API availability."
-            exit "$curl_exit"
-          }
-
-          verified=$(echo "$response" | jq -r '.commit.verification.verified')
-
-          # If the commit is not verified, list it and exit with a non-zero status
-          if [[ "$verified" != "true" ]]; then
-            echo "GPG signature verification failed for commit $commit."
-            exit 1
-          fi
-        done
+    uses: frmscoe/workflows/.github/workflows/gpg-verify-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -122,7 +122,7 @@ jobs:
           mkdir -p temp-workflows
           cp -r .github/workflows/* temp-workflows/
           rm temp-workflows/sync-workflows.yml  # avoid recursive syncing
-          rm -f temp-workflows/node-ci.yml       # reusable workflow stays in this repo; consumer repos reference it at runtime via @dev
+          rm -f temp-workflows/*-ci.yml          # reusable workflows stay in this repo; consumer repos reference them at runtime via @dev
 
           for repo in $REPOS; do
             git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/frmscoe/$repo.git


### PR DESCRIPTION
## Pilot: gpg-verify stub migration

First step of frmscoe/workflows#98 - bring the frmscoe rule fleet onto the caller-stub + reusable-workflow CI architecture. This PR proves the pattern on a single check (`gpg-verify`) before rolling out the remaining 10.

Do **not** merge yet - this is for review and a single-repo dry-run of the sync fan-out.

## Changes

- **Port reusable `gpg-verify-ci.yml`** from `tazama-lf/workflows` into this repo (Option A - self-hosted mirror, no cross-org runtime dependency for production repos). Logic is byte-identical to the previous inlined template.
- **Convert `gpg-verify.yml` to a thin caller stub** delegating to `frmscoe/workflows/.github/workflows/gpg-verify-ci.yml@dev`, with least-privilege `permissions: contents: read` copied from the tazama-lf stub.
- **Fix the sync exclusion glob** in `sync-workflows.yml`: `rm -f temp-workflows/node-ci.yml` becomes `rm -f temp-workflows/*-ci.yml`, so reusable workflows stay central and are never distributed into the 33 member repos. This is the highest-impact item and a prerequisite for every subsequent reusable.

## Why self-hosted (Option A)

`gpg-verify.yml` was fully inlined here and copied verbatim into all 33 rule repos, so each was a private drifting copy. Pointing the stub at frmscoe's own reusable keeps a single source of truth without taking a cross-org `@dev` dependency on `tazama-lf/workflows` for production CI.

## Verification before wider rollout

- [ ] Reusable `gpg-verify-ci.yml` present and `workflow_call`-enabled.
- [ ] Stub is ~15 lines, `uses:` + `secrets: inherit`, no inline `run:` blocks.
- [ ] Dry-run the sync (`workflow_dispatch`) against a single rule repo; confirm it receives the stub, **no** `*-ci.yml`, and CI is green.
- [ ] Confirm `SSH_SIGNING_KEY` secret is present before any fan-out.

## Not in scope here

The remaining 10 reusables (`branch-target-check-ci`, `codacy-ci`, `codeql-ci`, `conventional-commits-ci`, `dco-check-ci`, `dependency-review-ci`, `dockerfile-linter-ci`, `encoding-check-ci`, `njsscan-ci`, `sbom-ci`), the `codacy.yml` cross-org repoint, and the `encoding-check` addition follow in a subsequent PR once this pattern is validated.

Refs frmscoe/workflows#98
