### PR TITLE
ci: complete stub-architecture migration (remaining 10 checks)

### DIFF
--- a/.github/workflows/branch-target-check-ci.yml
+++ b/.github/workflows/branch-target-check-ci.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable branch target check workflow.
+# Called by consumer repos via a thin stub (branch-target-check.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Branch target check (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  check-source-branch:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR source branch is dev or release/v<N>.*
+        env:
+          SOURCE: ${{ github.head_ref }}
+        run: |
+          if [[ "$SOURCE" == "dev" || "$SOURCE" == release/v[0-9]* || "$SOURCE" == "sync-workflows-update-main" ]]; then
+            echo "✅ Source branch '$SOURCE' is a valid base for a PR to main."
+          else
+            echo "❌ PRs to main must come from 'dev' or a 'release/v<N>.*' branch (e.g. release/v1.2)."
+            echo "   This PR is from '$SOURCE'."
+            echo ""
+            echo "   If you are working on a feature or fix, please retarget this PR to 'dev':"
+            echo "     gh pr edit --base dev"
+            echo ""
+            echo "   Only 'dev' → main (via release-train.yml), 'release/v<N>.*' → main, and"
+            echo "   'sync-workflows-update-main' → main (automated workflow sync) merges are permitted."
+            exit 1
+          fi

--- a/.github/workflows/branch-target-check.yml
+++ b/.github/workflows/branch-target-check.yml
@@ -1,19 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Enforces the feature-branch → dev → main development workflow.
-#
-# When `main` is the default branch, GitHub pre-selects it as the PR base in the
-# UI and in `gh pr create`. This check fails immediately with a clear, actionable
-# message if a PR targets main from any branch other than `dev` or `release/v<N>.*`,
-# saving developers from a confusing "branch is locked" error or a misleading
-# "prerelease version detected" message from version-check.yml.
-#
-# Allowed sources for PRs to main:
-#   dev          - the normal integration branch
-#   release/v<N>.* - release-train branches created by release-train.yml (must start with a digit)
-#
-# Please do not attempt to edit this flow without the direct consent from the DevOps team.
-# This file is managed centrally.
+# Caller stub: delegates all branch target check logic to the centralised reusable workflow.
+# Logic changes belong in branch-target-check-ci.yml - do not add steps here.
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
 name: Branch target check
 
@@ -26,23 +16,6 @@ on:
       - main
 
 jobs:
-  check-source-branch:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify PR source branch is dev or release/v<N>.*
-        env:
-          SOURCE: ${{ github.head_ref }}
-        run: |
-          if [[ "$SOURCE" == "dev" || "$SOURCE" == release/v[0-9]* ]]; then
-            echo "✅ Source branch '$SOURCE' is a valid base for a PR to main."
-          else
-            echo "❌ PRs to main must come from 'dev' or a 'release/v<N>.*' branch (e.g. release/v1.2)."
-            echo "   This PR is from '$SOURCE'."
-            echo ""
-            echo "   If you are working on a feature or fix, please retarget this PR to 'dev':"
-            echo "     gh pr edit --base dev"
-            echo ""
-            echo "   Only 'dev' → main (via release-train.yml) and 'release/v<N>.*' → main merges are permitted."
-            exit 1
-          fi
+  branch-target-check:
+    uses: frmscoe/workflows/.github/workflows/branch-target-check-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/codacy-ci.yml
+++ b/.github/workflows/codacy-ci.yml
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable Codacy Security Scan workflow.
+# Called by consumer repos via a thin stub (codacy.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Codacy Security Scan (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  codacy-security-scan:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Codacy Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          verbose: true
+          output: results.sarif
+          format: sarif
+          # Adjust severity of non-security issues
+          gh-code-scanning-compat: true
+          # Force 0 exit code to allow SARIF file generation
+          # This will handover control about PR rejection to the GitHub side
+          max-allowed-issues: 2147483647
+          # Disable dockerized tools (e.g. Checkov) - not applicable to TypeScript/Node.js repos.
+          # ESLint and Semgrep run natively and are controlled via .codacy.yml.
+          run-docker-tools: 'false'
+
+      # Codacy outputs one SARIF run per engine. The CodeQL upload-sarif action rejects
+      # files with multiple runs sharing the same category (enforced since 2025-07-21).
+      # Merge all runs into one before uploading.
+      # Guard: when Codacy runs unauthenticated with no applicable findings it exits 0
+      # but does not write results.sarif. Create a minimal valid SARIF in that case so
+      # the upload step does not error on a missing or empty file.
+      - name: Merge SARIF runs into single run
+        run: |
+          if [ ! -s results.sarif ]; then
+            echo '{"$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","version":"2.1.0","runs":[{"tool":{"driver":{"name":"Codacy","rules":[]}},"results":[]}]}' > results.sarif
+          fi
+          jq '
+            if (.runs | length) > 1 then
+              .runs = [{
+                "tool": {
+                  "driver": {
+                    "name": "Codacy",
+                    "informationUri": "https://www.codacy.com",
+                    "rules": ([.runs[].tool.driver.rules[]?] | unique_by(.id))
+                  }
+                },
+                "results": [.runs[].results[]?]
+              }]
+            else . end
+          ' results.sarif > merged.sarif && mv merged.sarif results.sarif
+
+      - name: Upload SARIF results file
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+        with:
+          sarif_file: results.sarif
+          category: codacy

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Caller stub: delegates all Codacy scan logic to the centralised reusable workflow.
-# Logic changes belong in codacy-ci.yml in tazama-lf/workflows - do not add steps here.
+# Logic changes belong in codacy-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -22,5 +22,5 @@ permissions:
 
 jobs:
   codacy-security-scan:
-    uses: tazama-lf/workflows/.github/workflows/codacy-ci.yml@dev
+    uses: frmscoe/workflows/.github/workflows/codacy-ci.yml@dev
     secrets: inherit

--- a/.github/workflows/codeql-ci.yml
+++ b/.github/workflows/codeql-ci.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable CodeQL analysis workflow.
+# Called by consumer repos via a thin stub (codeql.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: "CodeQL (reusable)"
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,16 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
+# Caller stub: delegates all CodeQL analysis logic to the centralised reusable workflow.
+# Logic changes belong in codeql-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -20,59 +11,16 @@ on:
   push:
     branches: [ "dev", "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "dev", "main" ]
   schedule:
     - cron: '34 0 * * 4'
 
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
 jobs:
-  analyze:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Use only 'java' to analyze code written in Java, Kotlin or both
-        # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
-      with:
-        category: "/language:${{matrix.language}}"
+  codeql:
+    uses: frmscoe/workflows/.github/workflows/codeql-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/conventional-commits-ci.yml
+++ b/.github/workflows/conventional-commits-ci.yml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable PR conventional commit validation workflow.
+# Called by consumer repos via a thin stub (conventional-commits.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: PR Conventional Commit Validation (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-pr-title:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: PR Conventional Commit Validation
+        uses: ytanikin/PRConventionalCommits@b7be9213c4fa33260646db6c9b905332dc90b310  # 1.1.0
+        with:
+          task_types: '["build","ci","docs","feat","fix","perf","refactor","style","test","feat!"]'
+          custom_labels: '{"build": "build", "ci": "CI/CD", "docs": "documentation", "feat": "enhancement", "fix": "bug", "perf": "performance", "refactor": "refactor", "style": "style", "test": "test", "feat!": "enhancement breaking change"}'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add_label: 'true'

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,18 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This GitHub Actions workflow validates the title of pull requests (PRs) to ensure they follow conventional commit standards.
+# Caller stub: delegates all PR conventional commit validation logic to the centralised reusable workflow.
+# Logic changes belong in conventional-commits-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
 name: PR Conventional Commit Validation
 
 on:
-  # Trigger this workflow on specific events related to pull requests
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
@@ -22,20 +17,6 @@ permissions:
   issues: write
 
 jobs:
-  validate-pr-title:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest  # Use the latest Ubuntu runner for the job
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: PR Conventional Commit Validation
-        uses: ytanikin/PRConventionalCommits@b7be9213c4fa33260646db6c9b905332dc90b310  # 1.1.0
-        with:
-          # Define the task types that are valid for conventional commits
-          task_types: '["build","ci","docs","feat","fix","perf","refactor","style","test","feat!"]'
-          # Map the conventional commit types to corresponding GitHub labels
-          custom_labels: '{"build": "build", "ci": "CI/CD", "docs": "documentation", "feat": "enhancement", "fix": "bug", "perf": "performance", "refactor": "refactor", "style": "style", "test": "test", "feat!": "enhancement breaking change"}'
-          # Use a personal access token (GITHUB_TOKEN) stored in GitHub secrets for authentication
-          token: ${{ secrets.GITHUB_TOKEN }}
-          add_label: 'true'
+  conventional-commits:
+    uses: frmscoe/workflows/.github/workflows/conventional-commits-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/dco-check-ci.yml
+++ b/.github/workflows/dco-check-ci.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable DCO check workflow.
+# Called by consumer repos via a thin stub (dco-check.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: DCO (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'dependabot-preview[bot]' &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        fetch-depth: 0
+
+    - name: Set up environment variables
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        printf 'BASE_SHA=%s\n' "$PR_BASE_SHA" >> "$GITHUB_ENV"
+        printf 'HEAD_SHA=%s\n' "$PR_HEAD_SHA" >> "$GITHUB_ENV"
+
+    - name: Check for DCO Sign-off
+      run: |
+        commits=$(git log --pretty=format:%H "$BASE_SHA..$HEAD_SHA")
+        non_compliant_commits=""
+
+        for commit in $commits; do
+          if ! git show --quiet --format=%B "$commit" | grep -q "^Signed-off-by: "; then
+            non_compliant_commits="$non_compliant_commits $commit"
+          fi
+        done
+
+        if [ -n "$non_compliant_commits" ]; then
+          echo "The following commits do not have a Signed-off-by line:"
+          for commit in $non_compliant_commits; do
+            echo "- $commit"
+          done
+          exit 1
+        fi
+      shell: bash

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,59 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This GitHub Actions workflow checks that all commits in a pull request (PR) have a "Signed-off-by" line to ensure Developer Certificate of Origin (DCO) compliance.
+# Caller stub: delegates all DCO check logic to the centralised reusable workflow.
+# Logic changes belong in dco-check-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
 name: DCO
 
-# Trigger the workflow on pull request events
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
-  dco:
-    if: |
-      github.actor != 'dependabot[bot]' &&
-      github.actor != 'dependabot-preview[bot]' &&
-      github.actor != 'github-actions[bot]'
-    # Define the runner environment
-    runs-on: ubuntu-latest
-    
-    steps:
-    # Step to check out the repository
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        fetch-depth: 0  # Fetch all history for all branches to ensure complete commit history is available
-
-    - name: Set up environment variables
-      env:
-        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-      run: |
-        printf 'BASE_SHA=%s\n' "$PR_BASE_SHA" >> "$GITHUB_ENV"
-        printf 'HEAD_SHA=%s\n' "$PR_HEAD_SHA" >> "$GITHUB_ENV"
-
-    # Step to check each commit in the pull request for a Signed-off-by line
-    - name: Check for DCO Sign-off
-      run: |
-        # Get the list of commit hashes introduced by this PR (head commits not yet in base)
-        commits=$(git log --pretty=format:%H "$BASE_SHA..$HEAD_SHA")
-        non_compliant_commits=""
-
-        # Loop through each commit and check for the Signed-off-by line
-        for commit in $commits; do
-          # Check if the commit message contains the Signed-off-by line
-          if ! git show --quiet --format=%B "$commit" | grep -q "^Signed-off-by: "; then
-            # If not, add the commit hash to the list of non-compliant commits
-            non_compliant_commits="$non_compliant_commits $commit"
-          fi
-        done
-
-        # If there are any non-compliant commits, output their hashes and fail the job
-        if [ -n "$non_compliant_commits" ]; then
-          echo "The following commits do not have a Signed-off-by line:"
-          for commit in $non_compliant_commits; do
-            echo "- $commit"
-          done
-          exit 1
-        fi
-      shell: bash
+  dco-check:
+    uses: frmscoe/workflows/.github/workflows/dco-check-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/dependency-review-ci.yml
+++ b/.github/workflows/dependency-review-ci.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable dependency review workflow.
+# Called by consumer repos via a thin stub (dependency-review.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Dependency Review (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Dependency Review Action
-#
-# This Action will scan dependency manifest files that change as part of a Pull Request, surfacing known-vulnerable versions of the packages declared or updated in the PR. Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable packages will be blocked from merging.
-#
-# Source repository: https://github.com/actions/dependency-review-action
-# Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
-
+# Caller stub: delegates all dependency review logic to the centralised reusable workflow.
+# Logic changes belong in dependency-review-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -18,9 +13,5 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout Repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0
+    uses: frmscoe/workflows/.github/workflows/dependency-review-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/dockerfile-linter-ci.yml
+++ b/.github/workflows/dockerfile-linter-ci.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable Hadolint Dockerfile linter workflow.
+# Called by consumer repos via a thin stub (dockerfile-linter.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Hadolint (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  hadolint:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    name: Run hadolint scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Run hadolint
+        id: hadolint
+        if: hashFiles('Dockerfile') != ''
+        uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183
+        with:
+          dockerfile: ./Dockerfile
+          format: sarif
+          output-file: hadolint-results.sarif
+          no-fail: true
+      - name: Upload analysis results to GitHub
+        if: steps.hadolint.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+        with:
+          sarif_file: hadolint-results.sarif
+          wait-for-processing: true

--- a/.github/workflows/dockerfile-linter.yml
+++ b/.github/workflows/dockerfile-linter.yml
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# hadoint is a Dockerfile linter written in Haskell
-# that helps you build best practice Docker images.
-# More details at https://github.com/hadolint/hadolint
+# Caller stub: delegates all Hadolint Dockerfile linting logic to the centralised reusable workflow.
+# Logic changes belong in dockerfile-linter-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -16,40 +11,16 @@ on:
   push:
     branches: [ "dev", "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "dev" ]
   schedule:
     - cron: '17 13 * * 0'
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 jobs:
-  hadolint:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    name: Run hadolint scanning
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-      - name: Run hadolint
-        id: hadolint
-        if: hashFiles('Dockerfile') != ''
-        uses: hadolint/hadolint-action@f988afea3da57ee48710a9795b6bb677cc901183
-        with:
-          dockerfile: ./Dockerfile
-          format: sarif
-          output-file: hadolint-results.sarif
-          no-fail: true
-
-      - name: Upload analysis results to GitHub
-        if: steps.hadolint.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
-        with:
-          sarif_file: hadolint-results.sarif
-          wait-for-processing: true
+  dockerfile-linter:
+    uses: frmscoe/workflows/.github/workflows/dockerfile-linter-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/encoding-check-ci.yml
+++ b/.github/workflows/encoding-check-ci.yml
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable encoding check workflow.
+# Called by consumer repos via a thin stub (encoding-check.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Encoding Check (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  encoding-check:
+    permissions:
+      contents: read
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'dependabot-preview[bot]' &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Check file encodings
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mapfile -t changed_files < <(git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA")
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "No files changed in this PR."
+            exit 0
+          fi
+
+          violations=0
+
+          for f in "${changed_files[@]}"; do
+            bom=$(head -c 3 "$f" | xxd -p | tr -d '\n' | cut -c1-6)
+
+            case "$bom" in
+              fffe* | feff*)
+                echo "::error file=${f}::Non-UTF-8 encoding detected: UTF-16 (BOM: ${bom}). Re-save the file as UTF-8 without BOM."
+                violations=$((violations + 1))
+                ;;
+              efbbbf)
+                echo "::error file=${f}::UTF-8 BOM detected (EF BB BF). Re-save the file as UTF-8 without BOM."
+                violations=$((violations + 1))
+                ;;
+            esac
+          done
+
+          if [ "$violations" -gt 0 ]; then
+            echo ""
+            echo "Found ${violations} file(s) with non-UTF-8-no-BOM encoding."
+            echo "To fix: open each flagged file in your editor and re-save as 'UTF-8' (not 'UTF-8 with BOM', not 'UTF-16')."
+            echo "In VS Code: click the encoding indicator in the status bar → 'Save with Encoding' → 'UTF-8'."
+            exit 1
+          fi
+
+          echo "All ${#changed_files[@]} changed file(s) passed the encoding check."
+        shell: bash

--- a/.github/workflows/encoding-check.yml
+++ b/.github/workflows/encoding-check.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Caller stub: delegates all encoding check logic to the centralised reusable workflow.
+# Logic changes belong in encoding-check-ci.yml - do not add steps here.
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Encoding Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  encoding-check:
+    uses: frmscoe/workflows/.github/workflows/encoding-check-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/njsscan-ci.yml
+++ b/.github/workflows/njsscan-ci.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable njsscan SARIF workflow.
+# Called by consumer repos via a thin stub (njsscan.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: njsscan sarif (reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  njsscan:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    runs-on: ubuntu-latest
+    name: njsscan code scanning
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: nodejsscan scan
+      id: njsscan
+      continue-on-error: true
+      uses: ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81
+      with:
+        args: '. --sarif --output results.sarif'
+    - name: Upload njsscan report
+      uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
+      if: steps.njsscan.outcome == 'success'
+      with:
+        sarif_file: results.sarif
+        category: njsscan

--- a/.github/workflows/njsscan.yml
+++ b/.github/workflows/njsscan.yml
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow integrates njsscan with GitHub's Code Scanning feature
-# nodejsscan is a static security code scanner that finds insecure code patterns in your Node.js applications
+# Caller stub: delegates all njsscan logic to the centralised reusable workflow.
+# Logic changes belong in njsscan-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -16,35 +11,16 @@ on:
   push:
     branches: [ "dev", "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "dev", "main" ]
   schedule:
     - cron: '17 17 * * 1'
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 jobs:
   njsscan:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
-    runs-on: ubuntu-latest
-    name: njsscan code scanning
-    steps:
-    - name: Checkout the code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - name: nodejsscan scan
-      id: njsscan
-      continue-on-error: true
-      uses: ajinabraham/njsscan-action@d58d8b2f26322cd35a9efb8003baac517f226d81
-      with:
-        args: '. --sarif --output results.sarif'
-    - name: Upload njsscan report
-      uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699  # v3
-      if: steps.njsscan.outcome == 'success'
-      with:
-        sarif_file: results.sarif
-        category: njsscan
+    uses: frmscoe/workflows/.github/workflows/njsscan-ci.yml@dev
+    secrets: inherit

--- a/.github/workflows/sbom-ci.yml
+++ b/.github/workflows/sbom-ci.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Reusable Anchore Syft SBOM scan workflow.
+# Called by consumer repos via a thin stub (sbom.yml) that uses this workflow.
+# Logic changes belong here - do not add steps to the stub.
+# For more information see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows
+
+# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+
+name: Anchore Syft SBOM scan (reusable)
+
+on:
+  workflow_call:
+    secrets:
+      GH_TOKEN_LIB:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  Anchore-Build-Scan:
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Build the Docker image
+      if: hashFiles('Dockerfile') != ''
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+      run: docker build --secret id=GH_TOKEN,env=GH_TOKEN --file Dockerfile --tag localbuild/testimage:latest .
+    - name: Scan the image and upload dependency results
+      if: hashFiles('Dockerfile') != ''
+      uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
+      with:
+        image: "localbuild/testimage:latest"
+        artifact-name: image.spdx.json
+        dependency-snapshot: true

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,18 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-# This workflow checks out code, builds an image, performs a container image
-# scan with Anchore's Syft tool, and uploads the results to the GitHub Dependency
-# submission API.
-
-# For more information on the Anchore sbom-action usage
-# and parameters, see https://github.com/anchore/sbom-action. For more
-# information about the Anchore SBOM tool, Syft, see
-# https://github.com/anchore/syft
+# Caller stub: delegates all Anchore Syft SBOM scan logic to the centralised reusable workflow.
+# Logic changes belong in sbom-ci.yml - do not add steps here.
 
 # Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
 
@@ -24,25 +13,9 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
-  Anchore-Build-Scan:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    permissions:
-      contents: write # required to upload to the Dependency submission API
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout the code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - name: Build the Docker image
-      if: hashFiles('Dockerfile') != ''
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
-      run: docker build --secret id=GH_TOKEN,env=GH_TOKEN --file Dockerfile --tag localbuild/testimage:latest .
-    - name: Scan the image and upload dependency results
-      if: hashFiles('Dockerfile') != ''
-      uses: anchore/sbom-action@bb716408e75840bbb01e839347cd213767269d4a
-      with:
-        image: "localbuild/testimage:latest"
-        artifact-name: image.spdx.json
-        dependency-snapshot: true
+  sbom:
+    uses: frmscoe/workflows/.github/workflows/sbom-ci.yml@dev
+    secrets: inherit


### PR DESCRIPTION
## Summary

Completes the rule-fleet migration to the caller-stub + reusable-workflow CI architecture (issue #98). This is the central, one-shot change that lets `frmscoe/workflows` self-host every check so member rule repos carry only thin caller stubs - matching the pattern `tazama-lf/workflows` already uses.

The `gpg-verify` pilot (#99) proved the mechanics. This PR ports the remaining 10 checks in one reviewed change.

## What changed

**10 reusable workflows added** (`workflow_call`, live only in central):

- `branch-target-check-ci.yml`
- `codacy-ci.yml`
- `codeql-ci.yml`
- `conventional-commits-ci.yml`
- `dco-check-ci.yml`
- `dependency-review-ci.yml`
- `dockerfile-linter-ci.yml`
- `encoding-check-ci.yml`
- `njsscan-ci.yml`
- `sbom-ci.yml`

**8 inlined templates converted to thin caller stubs** (delegate to `frmscoe/workflows/.github/workflows/<check>-ci.yml@dev`, `secrets: inherit`):

`branch-target-check`, `codeql`, `conventional-commits`, `dco-check`, `dependency-review`, `dockerfile-linter`, `njsscan`, `sbom`

**1 new stub added:** `encoding-check` (previously absent from the fleet).

**1 cross-org dependency removed:** `codacy.yml` was the only workflow with a genuine cross-org runtime dependency (it delegated to `tazama-lf/workflows/.../codacy-ci.yml`). It now points at the frmscoe-hosted `codacy-ci.yml`. The rule fleet no longer has any cross-org coupling.

## Provenance

Reusables and stub trigger surfaces are copied verbatim from the `tazama-lf/workflows` canonical source and org-swapped, so the two rule fleets stay aligned. No `with:` inputs are introduced - every stub uses `secrets: inherit` only.

## Validation

A local simulation of the `sync-workflows.yml` copy loop confirms:

- 15 workflow files delivered to member repos; **0** `*-ci.yml` reusables leaked
- all 11 stubs (`gpg-verify` + the 10 here) delivered, pointing at `frmscoe/workflows`, with no inline `run:` steps
- `package-rule*` stamping and `scorecard.yml` delivery unaffected

## Rollout after merge

When this merges into `dev`, `sync-workflows.yml` fires once and replaces the 33 currently-open thin `gpg-verify` sync PRs with full-content PRs across the rule fleet. Those are then wave-merged (~5 at a time) with member-side Actions validated per wave.

Refs #98
