### PR TITLE
fix(ci): pin RC reusable workflow checkout to dev

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - name: Checkout rule repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0

--- a/workflow-docs/package-rule-rc.md
+++ b/workflow-docs/package-rule-rc.md
@@ -60,6 +60,7 @@ jobs:
 ## Known Limitations / Notes
 
 - The comment block in the canonical `frmscoe/workflows/package-rule-rc.yml` file shows a `tazama-lf/workflows` caller stub example - this is incorrect; frmscoe rule repos should reference `frmscoe/workflows`. The caller stubs stamped by `sync-workflows.yml` are correct.
+- The checkout step is pinned to `ref: dev`. RC builds must always read the rc line, but `actions/checkout` defaults to the ref that triggered the run - and under `repository_dispatch` (and `workflow_dispatch` once the default branch is `main`) that fallback is the repository default branch, not `dev`. Consumer rule repos pivoted their default branch from `dev` to `main`, so without the explicit `ref: dev` a dispatch-triggered run checked out `main` (a stable version) and failed the prerelease guard. Do not remove the `ref: dev` pin.
 - `dependabot[bot]` actors are excluded.
 
 ---


### PR DESCRIPTION
## What

Pin the release-candidate reusable workflow's checkout step to `ref: dev` so RC builds always read the rc line regardless of trigger or repository default branch.

Downstream mirror of tazama-lf/workflows PR #148 (issue tazama-lf/workflows#147).

## Why

`package-rule-rc.yml` used a bare `actions/checkout` with no `ref:`. `actions/checkout` defaults to the ref that triggered the run; under `repository_dispatch` (and `workflow_dispatch` once the default branch is `main`) that fallback is the repository default branch. Consumer rule repos pivoted their default branch from `dev` to `main`, so dispatch-triggered RC builds checked out the stable `main` line (a non-prerelease version) and failed the prerelease guard in the "Read rule version from package.json" step with `exit 1`.

## Changes

- `.github/workflows/package-rule-rc.yml` - `Checkout rule repository` -> `ref: dev`
- `workflow-docs/package-rule-rc.md` - recorded the pin and rationale

## Not changed (deliberate)

- `package-rule.yml` (stable): reads the `main` line; default-branch fallback already resolves to `main`.

frmscoe/workflows has no dockerhub image-build workflows, so only the one RC workflow required the fix.
