### PR TITLE
ci: standardize Slack notifications across publish workflows

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -206,36 +206,30 @@ jobs:
           docker rmi "${IMAGE}:${VERSION}" "${IMAGE}:rc"
           echo "RC image pushed: ${IMAGE}:${VERSION} and ${IMAGE}:rc"
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          echo "PR_URL=${PR_URL}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack notification
+        if: always()
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SERVICE_NAME: rule-${{ inputs.rule_number }}
+          IMAGE_REPOSITORY: tazamaorg/rule-${{ inputs.rule_number }}:rc
+          IMAGE_URL: https://hub.docker.com/r/tazamaorg/rule-${{ inputs.rule_number }}
+          RULE_VERSION: ${{ steps.rule_version.outputs.VERSION }}
+          PR_URL: ${{ steps.src_pr.outputs.PR_URL }}
+          JOB_STATUS: ${{ job.status }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          curl -s -X POST -H 'Content-type: application/json' --data '{
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "New Rule RC Docker image published :ship:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Rule:*\nrule-${{ inputs.rule_number }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Version:*\n${{ steps.rule_version.outputs.VERSION }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*DockerHub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"
-                  }
-                ]
-              }
-            ]
-          }' "$SLACK_WEBHOOK_URL" || true
+          [ -z "$SLACK_WEBHOOK_URL" ] && echo "SLACK_WEBHOOK_URL is not configured. Skipping Slack notification." && exit 0
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          curl --fail-with-body -sS -X POST -H 'Content-type: application/json' --data "$(jq -n --arg title "$([ "$JOB_STATUS" = "success" ] && echo "New Rule RC Docker image published :ship:" || echo "Rule RC Docker image build failed :x:")" --arg service "$SERVICE_NAME" --arg status "$JOB_STATUS" --arg version "$RULE_VERSION" --arg image "$IMAGE_REPOSITORY" --arg image_url "$IMAGE_URL" --arg branch "$BRANCH_NAME" --arg sha "$SHORT_SHA" --arg pr "$PR_URL" --arg run "$RUN_URL" '{blocks:[{type:"header",text:{type:"plain_text",text:$title,emoji:true}},{type:"section",fields:([{type:"mrkdwn",text:("*Rule:*\n"+$service)},{type:"mrkdwn",text:("*Status:*\n"+$status)},{type:"mrkdwn",text:("*Version:*\n`"+$version+"`")},{type:"mrkdwn",text:("*Image:*\n`"+$image+"`")},{type:"mrkdwn",text:("*Branch:*\n`"+$branch+"`")},{type:"mrkdwn",text:("*Commit:*\n`"+$sha+"`")},{type:"mrkdwn",text:("*DockerHub:*\n<"+$image_url+"|Open image>")},{type:"mrkdwn",text:("*Workflow Run:*\n<"+$run+"|Open run>")}]+(if $pr != "" then [{type:"mrkdwn",text:("*Source PR:*\n<"+$pr+"|Open PR>")}] else [] end))}]}')" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -183,36 +183,30 @@ jobs:
           docker rmi "${IMAGE}:${VERSION}" "${IMAGE}:latest"
           echo "Stable image pushed: ${IMAGE}:${VERSION} and ${IMAGE}:latest"
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          echo "PR_URL=${PR_URL}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack notification
+        if: always()
+        continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SERVICE_NAME: rule-${{ inputs.rule_number }}
+          IMAGE_REPOSITORY: tazamaorg/rule-${{ inputs.rule_number }}:latest
+          IMAGE_URL: https://hub.docker.com/r/tazamaorg/rule-${{ inputs.rule_number }}
+          RULE_VERSION: ${{ steps.rule_version.outputs.VERSION }}
+          PR_URL: ${{ steps.src_pr.outputs.PR_URL }}
+          JOB_STATUS: ${{ job.status }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          curl -s -X POST -H 'Content-type: application/json' --data '{
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "New Rule stable Docker image published :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Rule:*\nrule-${{ inputs.rule_number }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Version:*\n${{ steps.rule_version.outputs.VERSION }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*DockerHub:*\n<https://hub.docker.com/orgs/tazamaorg/repositories>"
-                  }
-                ]
-              }
-            ]
-          }' "$SLACK_WEBHOOK_URL" || true
+          [ -z "$SLACK_WEBHOOK_URL" ] && echo "SLACK_WEBHOOK_URL is not configured. Skipping Slack notification." && exit 0
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          curl --fail-with-body -sS -X POST -H 'Content-type: application/json' --data "$(jq -n --arg title "$([ "$JOB_STATUS" = "success" ] && echo "New Rule stable Docker image published :white_check_mark:" || echo "Rule stable Docker image build failed :x:")" --arg service "$SERVICE_NAME" --arg status "$JOB_STATUS" --arg version "$RULE_VERSION" --arg image "$IMAGE_REPOSITORY" --arg image_url "$IMAGE_URL" --arg branch "$BRANCH_NAME" --arg sha "$SHORT_SHA" --arg pr "$PR_URL" --arg run "$RUN_URL" '{blocks:[{type:"header",text:{type:"plain_text",text:$title,emoji:true}},{type:"section",fields:([{type:"mrkdwn",text:("*Rule:*\n"+$service)},{type:"mrkdwn",text:("*Status:*\n"+$status)},{type:"mrkdwn",text:("*Version:*\n`"+$version+"`")},{type:"mrkdwn",text:("*Image:*\n`"+$image+"`")},{type:"mrkdwn",text:("*Branch:*\n`"+$branch+"`")},{type:"mrkdwn",text:("*Commit:*\n`"+$sha+"`")},{type:"mrkdwn",text:("*DockerHub:*\n<"+$image_url+"|Open image>")},{type:"mrkdwn",text:("*Workflow Run:*\n<"+$run+"|Open run>")}]+(if $pr != "" then [{type:"mrkdwn",text:("*Source PR:*\n<"+$pr+"|Open PR>")}] else [] end))}]}')" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,34 +65,41 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
 
+      - name: Read package metadata
+        id: pkg
+        if: always()
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then DIST_TAG="rc"; else DIST_TAG="latest"; fi
+          echo "name=$NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          echo "PR_URL=${PR_URL}" >> "$GITHUB_OUTPUT"
+
       # Send Slack notification - requires SLACK_WEBHOOK_URL org/repo secret
       - name: Send Slack notification
+        if: always()
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SERVICE_NAME: ${{ steps.pkg.outputs.name }}
+          PACKAGE_REF: ${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }} (${{ steps.pkg.outputs.dist_tag }})
+          PACKAGE_URL: https://github.com/${{ github.repository }}/packages
+          PR_URL: ${{ steps.src_pr.outputs.PR_URL }}
+          JOB_STATUS: ${{ job.status }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "New npm package published :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Repository:*\nhttps://github.com/${{ github.repository }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Triggered by:*\n${{ github.actor }}"
-                  }
-                ]
-              }
-            ]
-          }' "$SLACK_WEBHOOK_URL"
+          [ -z "$SLACK_WEBHOOK_URL" ] && echo "SLACK_WEBHOOK_URL is not configured. Skipping Slack notification." && exit 0
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          curl --fail-with-body -sS -X POST -H 'Content-type: application/json' --data "$(jq -n --arg title "$([ "$JOB_STATUS" = "success" ] && echo "New npm package published :white_check_mark:" || echo "npm package publish failed :x:")" --arg service "$SERVICE_NAME" --arg status "$JOB_STATUS" --arg pkg "$PACKAGE_REF" --arg pkg_url "$PACKAGE_URL" --arg branch "$BRANCH_NAME" --arg sha "$SHORT_SHA" --arg pr "$PR_URL" --arg run "$RUN_URL" '{blocks:[{type:"header",text:{type:"plain_text",text:$title,emoji:true}},{type:"section",fields:([{type:"mrkdwn",text:("*Service:*\n"+$service)},{type:"mrkdwn",text:("*Status:*\n"+$status)},{type:"mrkdwn",text:("*Package:*\n`"+$pkg+"`")},{type:"mrkdwn",text:("*Branch:*\n`"+$branch+"`")},{type:"mrkdwn",text:("*Commit:*\n`"+$sha+"`")},{type:"mrkdwn",text:("*GitHub Packages:*\n<"+$pkg_url+"|Open packages>")},{type:"mrkdwn",text:("*Workflow Run:*\n<"+$run+"|Open run>")}]+(if $pr != "" then [{type:"mrkdwn",text:("*Source PR:*\n<"+$pr+"|Open PR>")}] else [] end))}]}')" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,33 +217,29 @@ jobs:
             --title "${{ steps.bump_version.outputs.new_version }}" \
             --notes-file /home/runner/work/changelog.txt
 
+      - name: Resolve source PR
+        id: src_pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_URL=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq '.[0].html_url // empty' 2>/dev/null || true)
+          echo "PR_URL=${PR_URL}" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
+        if: always()
         continue-on-error: true
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SERVICE_NAME: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.bump_version.outputs.new_version }}
+          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump_version.outputs.new_version }}
+          PR_URL: ${{ steps.src_pr.outputs.PR_URL }}
+          JOB_STATUS: ${{ job.status }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "New Release Alert :tazama:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Github Repository:*\nhttps://github.com/${{ github.repository }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Release:*\n<https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump_version.outputs.new_version }}|Release notes>"
-                  }
-                ]
-              }
-            ]
-          }' "$SLACK_WEBHOOK_URL"
+          [ -z "$SLACK_WEBHOOK_URL" ] && echo "SLACK_WEBHOOK_URL is not configured. Skipping Slack notification." && exit 0
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          curl --fail-with-body -sS -X POST -H 'Content-type: application/json' --data "$(jq -n --arg title "$([ "$JOB_STATUS" = "success" ] && echo "New Release Alert :tazama:" || echo "Release failed :x:")" --arg service "$SERVICE_NAME" --arg status "$JOB_STATUS" --arg release "$RELEASE_TAG" --arg release_url "$RELEASE_URL" --arg branch "$BRANCH_NAME" --arg sha "$SHORT_SHA" --arg pr "$PR_URL" --arg run "$RUN_URL" '{blocks:[{type:"header",text:{type:"plain_text",text:$title,emoji:true}},{type:"section",fields:([{type:"mrkdwn",text:("*Github Repository:*\n"+$service)},{type:"mrkdwn",text:("*Status:*\n"+$status)},{type:"mrkdwn",text:("*Release:*\n`"+$release+"`")},{type:"mrkdwn",text:("*Branch:*\n`"+$branch+"`")},{type:"mrkdwn",text:("*Commit:*\n`"+$sha+"`")},{type:"mrkdwn",text:("*Release notes:*\n<"+$release_url+"|Open release>")},{type:"mrkdwn",text:("*Workflow Run:*\n<"+$run+"|Open run>")}]+(if $pr != "" then [{type:"mrkdwn",text:("*Source PR:*\n<"+$pr+"|Open PR>")}] else [] end))}]}')" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Standardizes Slack notifications across the workflows that already post to Slack (package-rule, package-rule-rc, publish, release).
- Notifications now fire on success and failure (if: always()).
- Gracefully skip when SLACK_WEBHOOK_URL is unset.
- Richer Block Kit payload: Status, Branch, Commit, Workflow Run, optional Source PR.
- Added a Resolve source PR step (was absent in this repo).
- Existing success titles/emojis preserved; added failure variants.