### PR TITLE
ci: exclude release centrals from sync bundle

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -123,6 +123,15 @@ jobs:
           cp -r .github/workflows/* temp-workflows/
           rm temp-workflows/sync-workflows.yml  # avoid recursive syncing
           rm -f temp-workflows/*-ci.yml          # reusable workflows stay in this repo; consumer repos reference them at runtime via @dev
+          # Release/library workflows and reusable package-rule definitions live only in frmscoe/workflows.
+          # Rule repos either call them at runtime via @dev/@main, or receive thin caller stubs (package-rule*) stamped below.
+          rm -f temp-workflows/dev-to-main-pr.yml
+          rm -f temp-workflows/package-rule.yml
+          rm -f temp-workflows/package-rule-rc.yml
+          rm -f temp-workflows/publish.yml
+          rm -f temp-workflows/release.yml
+          rm -f temp-workflows/release-train.yml
+          rm -f temp-workflows/release-orchestrator.yml
 
           for repo in $REPOS; do
             git clone https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/frmscoe/$repo.git


### PR DESCRIPTION
## Summary
Adds the release-central exclusions to `sync-workflows.yml` **without** replacing org-specific sync logic (repo lists, Docker filters, package-rule stubs, etc.).

## What changes
After building `temp-workflows/`, also remove:
- `dev-to-main-pr.yml`
- `package-rule.yml` / `package-rule-rc.yml`
- `publish.yml` / `release.yml` / `release-train.yml`
- `release-orchestrator.yml` (if present)

Those stay in `frmscoe/workflows` only. Product repos get thin callers via bootstrap (later).

## Test plan
- [ ] Confirm REPOS / PUBLISH_REPOS / RULE_REPOS blocks unchanged
- [ ] Dry-run or inspect next sync: product PRs should not add full release-train/publish/release copies
