### PR TITLE
fix: publish.yml set GH_TOKEN on npm steps for repo-committed .npmrc (mirror of tazama-lf/workflows#161)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,16 +97,6 @@ jobs:
           registry-url: 'https://npm.pkg.github.com/'
           scope: ${{ inputs.package_scope || vars.PACKAGE_SCOPE || '@frmscoe' }}
 
-      - name: Set up npm authentication
-        shell: bash
-        env:
-          GH_TOKEN_LIB: ${{ secrets.GH_TOKEN_LIB }}
-        run: |
-          set -euo pipefail
-          echo "//npm.pkg.github.com/:_authToken=${GH_TOKEN_LIB}" >> ~/.npmrc
-          echo "@frmscoe:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-          echo "@tazama-lf:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-
       - name: Resolve package identity
         id: pkg
         shell: bash
@@ -134,6 +124,10 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+          # Repos carry a committed project-level .npmrc that authenticates with
+          # ${GH_TOKEN}; project .npmrc overrides setup-node's userconfig, so the
+          # token must also be exposed under that name.
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
         run: |
           set -euo pipefail
           NAME="${{ steps.pkg.outputs.name }}"
@@ -150,6 +144,7 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
         run: |
           set -euo pipefail
           if [ -f package-lock.json ]; then
@@ -168,6 +163,7 @@ jobs:
         shell: bash
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
         run: |
           set -euo pipefail
           npm publish --tag "${{ steps.pkg.outputs.dist_tag }}"


### PR DESCRIPTION
Mirror of tazama-lf/workflows#161 (root cause: tazama-lf/workflows#160). Copies the fixed `publish.yml` byte-for-byte from the canonical repo - the dev copies were byte-identical before this change.

## Summary

Fixes CI `npm publish` 401 failures in the central reusable `publish.yml`.

## Root cause

Library repos carry a committed project-level `.npmrc` that authenticates with `${GH_TOKEN}`. Project `.npmrc` overrides setup-node's userconfig, so `NODE_AUTH_TOKEN` never reaches the registry, the "Set up npm authentication" step's `~/.npmrc` writes are dead code (setup-node exports `NPM_CONFIG_USERCONFIG`), and `GH_TOKEN` is never set as an env var on the npm steps - it expands to empty and the publish PUT gets 401.

## Changes

- Add `GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}` to the env of the npm-facing steps ("Check if already published", "Install dependencies", "Publish package") - the same pattern already used by `package-rule.yml` and `package-rule-rc.yml`
- Remove the dead "Set up npm authentication" step

## Notes

- Callers reference this workflow via `@v1`; the `v1` tag must be moved after this merges for the fix to take effect
