### PR TITLE
fix: set GH_TOKEN on release-train npm steps for project .npmrc

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -239,6 +239,8 @@ jobs:
         id: resolve_deps
         shell: bash
         env:
+          # Project .npmrc uses ${GH_TOKEN}; NODE_AUTH_TOKEN alone is shadowed
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
           INTERNAL_SCOPES_REGEX: ${{ inputs.internal_scopes_regex || vars.INTERNAL_SCOPES_REGEX || '^@(tazama-lf|frmscoe)/' }}
         run: |
@@ -305,6 +307,7 @@ jobs:
       - name: Regenerate package-lock.json if present
         shell: bash
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
           NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
           HUSKY: "0"
         run: |


### PR DESCRIPTION
Project .npmrc uses ${GH_TOKEN}, so NODE_AUTH_TOKEN alone is shadowed and npm view fails when rewriting rc deps. Same pattern as publish. After merge, retag v1 and re-run orchestrator for frms-coe-startup-lib.