### PR TITLE
ci: stamp package-rule caller stubs with @v1 instead of @main

### DIFF
--- a/.github/workflows/sync-workflows.yml
+++ b/.github/workflows/sync-workflows.yml
@@ -202,7 +202,7 @@ jobs:
               '  workflow_dispatch:' \
               'jobs:' \
               '  build:' \
-              "    uses: frmscoe/workflows/.github/workflows/package-rule.yml@main" \
+              "    uses: frmscoe/workflows/.github/workflows/package-rule.yml@v1" \
               '    with:' \
               "      rule_number: \"${RULE_NUM}\"" \
               '      rule_org: "frmscoe"' \


### PR DESCRIPTION
## What

Changes the `package-rule.yml` caller-stub stamp in `sync-workflows.yml` (L205) from `@main` to `@v1`.

## Why

Mirrors [tazama-lf/workflows#170](https://github.com/tazama-lf/workflows/pull/170) - prerequisite 1 of [tazama-lf/workflows#169](https://github.com/tazama-lf/workflows/issues/169) (retire the stale `main` branch on both workflows repos):

- Deployed rule callers (all 33 frmscoe rule repos, verified on `rule-001@main`) already use `@v1` - the template is stale relative to reality.
- The `v1` tag tracks `dev` HEAD exactly (verified 2026-07-24: `v1` == `dev` == `9fc5f7f`), so `@v1` resolves to current workflow definitions.
- `main` is 72 commits behind `dev` and consumed by nothing; once it is deleted per the issue, a `@main` stamp would leave rule repos with a dangling ref on the next sync.

Note: the `on: push: branches: [main]` trigger line in the stub is untouched - it refers to the RULE repo's `main`, which is correct for stable builds.

Refs tazama-lf/workflows#169
